### PR TITLE
Add Websocket Support

### DIFF
--- a/addons/keh_network/network.gd
+++ b/addons/keh_network/network.gd
@@ -188,6 +188,8 @@ var _max_client_history_size: int = 60 setget noset
 # Value = instance of the NetEventInfo class
 var _event_info: Dictionary = {} setget noset
 
+var _is_websocket = false
+
 
 # Most of the unique IDs within the snapshots can be simply incrementing integers.
 # Often that can be easily done through an auto-load script. Taking advantage of
@@ -198,6 +200,10 @@ var _event_info: Dictionary = {} setget noset
 # this dictionary so avoid directly using it.
 var _incrementing_id: Dictionary setget noset
 
+func _enter_tree():
+	# placing it on _enter_tree because calling join_server is somehow called before _ready
+	if (ProjectSettings.has_setting("keh_addons/network/use_websocket")):
+		_is_websocket = ProjectSettings.get_setting("keh_addons/network/use_websocket")
 
 func _ready() -> void:
 	# Create the objects
@@ -222,7 +228,6 @@ func _ready() -> void:
 	# Obtain compression mode from ProjectSettings
 	if (ProjectSettings.has_setting("keh_addons/network/compression")):
 		_compression = ProjectSettings.get_setting("keh_addons/network/compression")
-	
 	
 	# Obtain the preference for broadcasting measured ping values
 	if (ProjectSettings.has_setting("keh_addons/network/broadcast_measured_ping")):
@@ -342,6 +347,9 @@ func get_input(player_id: int) -> InputData:
 
 ### Server...
 func create_server(port: int, _server_name: String, max_players: int) -> void:
+	if _is_websocket:
+		create_websocket_server(port, _server_name, max_players)
+		return
 	# Create the network API object
 	var net: NetworkedMultiplayerENet = NetworkedMultiplayerENet.new()
 	net.compression_mode = _compression
@@ -363,10 +371,6 @@ func create_server(port: int, _server_name: String, max_players: int) -> void:
 
 func create_websocket_server(port: int, _server_name: String, max_players: int) -> void:
 	var net = WebSocketServer.new()
-  
-  # without this websocket servers sometimes don't close the connection correctly
-	net.connect("client_disconnected", self, "_on_player_disconnected")
-	net.connect("client_close_request", self, "_on_player_close_req")
 	
 	if (net.listen(port, PoolStringArray(), true) != OK):
 		emit_signal("server_creation_failed")
@@ -429,9 +433,9 @@ func _on_player_disconnected(id: int) -> void:
 		_unregister_player(id)
 		# And from everyone else
 		# rpc("_unregister_player", id)
-    # deferred call otherwise we sometimes get a bug on websocket servers not correctly synchronizing the rpc
-    # sometimes it tries to send the rpc to the player that already left too (which somehow causes every client to ignore the rpc call)
-    call_deferred("rpc", "_unregister_player", id)
+	# deferred call otherwise we sometimes get a bug on websocket servers not correctly synchronizing the rpc
+	# sometimes it tries to send the rpc to the player that already left too (which somehow causes every client to ignore the rpc call)
+#	call_deferred("rpc", "_unregister_player", id)
 
 
 # Clients call this function to send credentials to servers
@@ -455,6 +459,10 @@ remote func server_receive_credentials(cred: Dictionary) -> void:
 
 ### Client...
 func join_server(_ip: String, _port: int) -> void:
+	if _is_websocket:
+		join_websocket_server(_ip, _port)
+		return
+
 	var net: NetworkedMultiplayerENet = NetworkedMultiplayerENet.new()
 	net.compression_mode = _compression
 	
@@ -494,8 +502,9 @@ func disconnect_from_server() -> void:
 	if (get_tree().is_network_server()):
 		return
 	
-	# Close the connection
-	get_tree().get_network_peer().close_connection()
+	if not _is_websocket:
+		# Close the connection
+		get_tree().get_network_peer().close_connection()
 	# Perform some cleanup
 	_handle_disconnection()
 

--- a/addons/keh_network/pluginloader.gd
+++ b/addons/keh_network/pluginloader.gd
@@ -33,6 +33,7 @@ func _enter_tree():
 	}
 	
 	_reg_setting("compression", TYPE_INT, NetworkedMultiplayerENet.COMPRESS_RANGE_CODER, compr)
+	_reg_setting("use_websocket", TYPE_BOOL, false)
 	_reg_setting("max_snapshot_history", TYPE_INT, 120)
 	_reg_setting("max_client_snapshot_history", TYPE_INT, 60)
 	_reg_setting("full_snapshot_threshold", TYPE_INT, 12)
@@ -53,6 +54,7 @@ func _exit_tree():
 	# Remove the additional project settings - those will remain on the ProjectSettings window until
 	# the editor is restarted
 	ProjectSettings.clear(base_path + "compression")
+	ProjectSettings.clear(base_path + "server_type")
 	ProjectSettings.clear(base_path + "max_snapshot_history")
 	ProjectSettings.clear(base_path + "max_client_snapshot_history")
 	ProjectSettings.clear(base_path + "full_snapshot_threshold")


### PR DESCRIPTION
Allows to use "create_websocket_server" to create a websocket server
Compression method and max_players is ignored as this is currently not implemented in the websocket implementation of godot

Max_Players could be simulated by counting the number of players manually and refusing new connections once the player count is equal to max_players

Afaik there's no way to get compression working for now

Allows clients to join a websocket server with "join_websocket_server"

This is far from perfect as there is still a bug where client disconnects are still not properly synchronized with other clients (even though the node is removed from the server)

The Websocket Implementation is compatible with Godots High Level Multiplayer so the rest should work fine.
However, i don't think rpc_unreliable is actually unreliable since websocket packets are always delivered in order and reliably (due to websocket limitations/being TCP connections)