### PR TITLE
Add option to enable/disable local input

### DIFF
--- a/addons/keh_network/network.gd
+++ b/addons/keh_network/network.gd
@@ -364,6 +364,9 @@ func get_input(player_id: int) -> InputData:
 	
 	return retval
 
+func set_local_input_enabled(enabled: bool) -> void:
+	player_data.local_player.local_input_enabled = enabled
+
 
 ### Server...
 func create_server(port: int, _server_name: String, max_players: int) -> void:

--- a/addons/keh_network/network.gd
+++ b/addons/keh_network/network.gd
@@ -365,7 +365,7 @@ func get_input(player_id: int) -> InputData:
 	return retval
 
 func set_local_input_enabled(enabled: bool) -> void:
-	player_data.local_player.local_input_enabled = enabled
+	player_data.local_player._local_input_enabled = enabled
 
 
 ### Server...

--- a/addons/keh_network/playernode.gd
+++ b/addons/keh_network/playernode.gd
@@ -149,7 +149,7 @@ var _mrelative: Vector2 = Vector2()
 var _mspeed: Vector2 = Vector2()
 
 # When set to false it will disable polling input for local player
-var local_input_enabled: bool = true
+var _local_input_enabled: bool = true
 
 ### Options retrieved from project settings
 var _broadcast_ping: bool = false
@@ -194,18 +194,18 @@ func _poll_input() -> InputData:
 	_input_cache.last_sig += 1
 	var retval: InputData = InputData.new(_input_cache.last_sig)
 	
-	if (_input_info.use_mouse_relative() && local_input_enabled):
+	if (_input_info.use_mouse_relative() && _local_input_enabled):
 		retval.set_mouse_relative(_mrelative)
 		# Must reset the cache otherwise motion will still be sent even if there is none
 		_mrelative = Vector2()
 	
-	if (_input_info.use_mouse_speed() && local_input_enabled):
+	if (_input_info.use_mouse_speed() && _local_input_enabled):
 		retval.set_mouse_speed(_mspeed)
 		_mspeed = Vector2()
 	
 	# Gather the analog data
 	for a in _input_info._analog_list:
-		if (!_input_info._analog_list[a].custom && local_input_enabled):
+		if (!_input_info._analog_list[a].custom && _local_input_enabled):
 			retval.set_analog(a, Input.get_action_strength(a))
 		else:
 			# Assume this analog data is "neutral". Doing this to ensure the data
@@ -213,7 +213,7 @@ func _poll_input() -> InputData:
 			retval.set_analog(a, 0.0)
 		
 	for b in _input_info._bool_list:
-		if (!_input_info._bool_list[b].custom && local_input_enabled):
+		if (!_input_info._bool_list[b].custom && _local_input_enabled):
 			retval.set_pressed(b, Input.is_action_pressed(b))
 		else:
 			# Assume this custom boolean is not pressed. Doing this to ensure the

--- a/addons/keh_network/playernode.gd
+++ b/addons/keh_network/playernode.gd
@@ -148,6 +148,9 @@ var _custom_data: Dictionary
 var _mrelative: Vector2 = Vector2()
 var _mspeed: Vector2 = Vector2()
 
+# When set to false it will disable polling input for local player
+var local_input_enabled: bool = true
+
 ### Options retrieved from project settings
 var _broadcast_ping: bool = false
 
@@ -191,18 +194,18 @@ func _poll_input() -> InputData:
 	_input_cache.last_sig += 1
 	var retval: InputData = InputData.new(_input_cache.last_sig)
 	
-	if (_input_info.use_mouse_relative()):
+	if (_input_info.use_mouse_relative() && local_input_enabled):
 		retval.set_mouse_relative(_mrelative)
 		# Must reset the cache otherwise motion will still be sent even if there is none
 		_mrelative = Vector2()
 	
-	if (_input_info.use_mouse_speed()):
+	if (_input_info.use_mouse_speed() && local_input_enabled):
 		retval.set_mouse_speed(_mspeed)
 		_mspeed = Vector2()
 	
 	# Gather the analog data
 	for a in _input_info._analog_list:
-		if (!_input_info._analog_list[a].custom):
+		if (!_input_info._analog_list[a].custom && local_input_enabled):
 			retval.set_analog(a, Input.get_action_strength(a))
 		else:
 			# Assume this analog data is "neutral". Doing this to ensure the data
@@ -210,7 +213,7 @@ func _poll_input() -> InputData:
 			retval.set_analog(a, 0.0)
 		
 	for b in _input_info._bool_list:
-		if (!_input_info._bool_list[b].custom):
+		if (!_input_info._bool_list[b].custom && local_input_enabled):
 			retval.set_pressed(b, Input.is_action_pressed(b))
 		else:
 			# Assume this custom boolean is not pressed. Doing this to ensure the


### PR DESCRIPTION
Because this library does not use _unhandled_input and uses directly Input.* it also interferes with GUI when you are typing something in UI, e.g. useful when you have chat in game overlay and you want to temporarly disable input while typing.

Usage:
`network.set_local_input_enabled(true/false)`