### PR TITLE
Allow change specific action enabled state

### DIFF
--- a/addons/keh_network/inputinfo.gd
+++ b/addons/keh_network/inputinfo.gd
@@ -88,6 +88,7 @@ func _register_data(container: Dictionary, n: String, c: bool) -> void:
 		container[n] = {
 			"mask": 1 << container.size(),
 			"custom": c,
+			"enabled": true
 		}
 	_has_custom_data = _has_custom_data || c
 
@@ -121,6 +122,16 @@ func reset_actions() -> void:
 	_vec2_list.clear()
 	_vec3_list.clear()
 	_has_custom_data = false
+
+
+# Set enabled state of action
+func set_action_enabled(map: String, enabled: bool) -> void:
+	if _analog_list.has(map):
+		_analog_list[map].enabled = enabled
+	elif _bool_list.has(map):
+		_bool_list[map].enabled = enabled
+	else:
+		push_warning("Trying to set action enabled state on non-existent action '%s'." % map)
 
 
 # Allow overriding the project setting related to the mouse relative

--- a/addons/keh_network/network.gd
+++ b/addons/keh_network/network.gd
@@ -354,6 +354,11 @@ func register_action(action: String, is_analog: bool) -> void:
 		var w: String = "Trying to register %s input action but it's not mapped. Please check Project Settings -> Input Map tab."
 		push_warning(w % action)
 
+
+func set_action_enabled(action: String, enabled: bool) -> void:
+	player_data.input_info.set_action_enabled(action, enabled)
+
+
 # Allows registration of custom input data within the input system. This will register either
 # a custom analog (is_analog = true) or a custom boolean state (is_analog = false)
 func register_custom_action(action: String, is_analog: bool) -> void:

--- a/addons/keh_network/playernode.gd
+++ b/addons/keh_network/playernode.gd
@@ -208,7 +208,7 @@ func _poll_input() -> InputData:
 	
 	# Gather the analog data
 	for a in _input_info._analog_list:
-		if (!_input_info._analog_list[a].custom && _local_input_enabled):
+		if (!_input_info._analog_list[a].custom && (_local_input_enabled && _input_info._analog_list[a].enabled)):
 			retval.set_analog(a, Input.get_action_strength(a))
 		else:
 			# Assume this analog data is "neutral". Doing this to ensure the data
@@ -216,7 +216,7 @@ func _poll_input() -> InputData:
 			retval.set_analog(a, 0.0)
 		
 	for b in _input_info._bool_list:
-		if (!_input_info._bool_list[b].custom && _local_input_enabled):
+		if (!_input_info._bool_list[b].custom && (_local_input_enabled && _input_info._bool_list[b].enabled)):
 			retval.set_pressed(b, Input.is_action_pressed(b))
 		else:
 			# Assume this custom boolean is not pressed. Doing this to ensure the


### PR DESCRIPTION
We have "_local_input_enabled " but sometimes you need to change enabled state only for specific action. Let's say you have mouse button bind for shooting in game. Now when user clicks something in HUD UI layer you want to disable temporarly mouse action click when user hovers UI controls but keep other controls enabled (e.g. user can click something in UI while moving).